### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.3', '8.4']
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "assoconnect/php-quality-config": "^1.16"
     },
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.3",
         "symfony/framework-bundle": "^6.0|^7.0",
         "assoconnect/php-percent": "^1.1",
         "doctrine/dbal": "^2.10|^3.0",


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4