### PR TITLE
Remove support for Symfony 6 and lower

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require-dev": {
-        "assoconnect/php-quality-config": "^1.16"
+        "assoconnect/php-quality-config": "^2"
     },
     "require": {
         "php": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     },
     "require": {
         "php": "^8.3",
-        "symfony/framework-bundle": "^6.0|^7.0",
+        "symfony/framework-bundle": "^7.0",
         "assoconnect/php-percent": "^1.1",
         "doctrine/dbal": "^2.10|^3.0",
-        "symfony/serializer": "^6.0|^7.0",
+        "symfony/serializer": "^7.0",
         "assoconnect/validator-bundle": "^2.32"
     },
     "config": {


### PR DESCRIPTION
## Summary
- Update symfony/framework-bundle and symfony/serializer constraints to require ^7.0 only
- Drop support for Symfony 6.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)