### PR TITLE
Upgrade PHPUnit configuration to version 10

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
   <php>
     <ini name="error_reporting" value="-1"/>
     <env name="KERNEL_CLASS" value="App\Kernel"/>
     <env name="APP_ENV" value="test"/>
     <env name="APP_DEBUG" value="1"/>
   </php>
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
   <testsuites>
     <testsuite name="main">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
## Summary
- Updates `phpunit.xml.dist` to use PHPUnit 10 schema
- Moves source directory configuration from `<coverage>` to `<source>` (PHPUnit 10 format)
- Removes deprecated `processUncoveredFiles` attribute

## Test plan
- [ ] All PHPUnit tests pass with no deprecation warnings
- [ ] phpcs passes
- [ ] phpstan passes
- [ ] rector --dry-run passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)