### PR TITLE
Clean CI and upgrade analysis tools to latest on lowest dependency runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,18 +15,24 @@ jobs:
         dependency-versions: ['lowest', 'highest']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      
+
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
-      
+
       - run: composer validate --strict
-      
-      - run: composer install --prefer-dist --no-progress --no-suggest
-      
+
+      - uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: ${{ matrix.dependency-versions }}
+
+      - name: Upgrade analysis tools to latest
+        if: ${{ matrix.dependency-versions == 'lowest' }}
+        run: composer update phpstan/phpstan rector/rector phpunit/phpunit squizlabs/php_codesniffer --with-all-dependencies --no-interaction
+
       - run: vendor/bin/phpcs
         if: ${{ failure() ||  success() }}
 
@@ -38,12 +44,12 @@ jobs:
 
       - run: XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover ./clover.xml --log-junit ./phpunit.report.xml
         if: ${{ failure() ||  success() }}
-      
+
       # https://community.sonarsource.com/t/code-coverage-doesnt-work-with-github-action/16747
       # $GITHUB_WORKSPACE contains a slash so @ is used as delimiter
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' clover.xml
       - run: sed -i 's@'$GITHUB_WORKSPACE'@/github/workspace/@g' phpunit.report.xml
-      
+
       - uses: sonarsource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /vendor/*
-.phpunit.result.cache
+.phpunit.cache
 .idea
 .php_cs.cache
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require-dev": {
-        "assoconnect/php-quality-config": "^2"
+        "assoconnect/php-quality-config": "^2.2"
     },
     "require": {
         "php": "^8.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,6 +5,7 @@
     <env name="KERNEL_CLASS" value="App\Kernel"/>
     <env name="APP_ENV" value="test"/>
     <env name="APP_DEBUG" value="1"/>
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
   </php>
   <testsuites>
     <testsuite name="main">


### PR DESCRIPTION
## Summary
- Replace `composer install` with `ramsey/composer-install@v2` for proper lowest/highest dependency support
- Upgrade `actions/checkout` from v2 to v4
- Add step to upgrade phpstan, rector, phpunit and phpcs to latest when running with lowest dependencies
- Add `SYMFONY_DEPRECATIONS_HELPER=weak` to `phpunit.xml.dist`
- Fix `.gitignore` cache file name

🤖 Generated with [Claude Code](https://claude.com/claude-code)