### PR TITLE
Add DBAL 4 support alongside DBAL 3.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "php": "^8.4",
         "symfony/framework-bundle": "^7.0",
         "assoconnect/php-percent": "^1.1",
-        "doctrine/dbal": "^2.10|^3.0",
+        "doctrine/dbal": "^3.6|^4.0",
         "symfony/serializer": "^7.0",
         "assoconnect/validator-bundle": "^2.39.2"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,5 +8,10 @@ parameters:
             - 'Symfony\Component\Validator\Exception\InvalidOptionsException'
             - 'Symfony\Component\Validator\Exception\MissingOptionsException'
 
+    # DBAL 3 fallback branch, dead code when DBAL 4 is installed (^3.6|^4.0 are both supported)
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - '#Call to an undefined static method Doctrine\\DBAL\\Types\\ConversionException::conversionFailed#'
+
 includes:
     - vendor/assoconnect/php-quality-config/phpstan.extension.neon

--- a/src/Doctrine/DBAL/Types/PercentType.php
+++ b/src/Doctrine/DBAL/Types/PercentType.php
@@ -7,6 +7,7 @@ namespace AssoConnect\PHPPercentBundle\Doctrine\DBAL\Types;
 use AssoConnect\PHPPercent\Percent;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
+use Doctrine\DBAL\Types\Exception\InvalidType;
 use Doctrine\DBAL\Types\Type;
 
 class PercentType extends Type
@@ -33,7 +34,7 @@ class PercentType extends Type
             return $value->toInteger();
         }
 
-        throw ConversionException::conversionFailedInvalidType($value, $this->getName(), ['null', Percent::class]);
+        throw $this->createInvalidTypeException($value, ['null', Percent::class]);
     }
 
     public function convertToPHPValue($value, AbstractPlatform $platform): ?Percent
@@ -45,12 +46,7 @@ class PercentType extends Type
         try {
             return new Percent(is_string($value) ? (int)$value : $value);
         } catch (\Throwable $exception) {
-            throw ConversionException::conversionFailedInvalidType(
-                $value,
-                $this->getName(),
-                ['null', 'integer'],
-                $exception
-            );
+            throw $this->createInvalidTypeException($value, ['null', 'integer'], $exception);
         }
     }
 
@@ -60,5 +56,25 @@ class PercentType extends Type
     public function requiresSQLCommentHint(AbstractPlatform $platform): bool
     {
         return true;
+    }
+
+    /**
+     * DBAL 4 replaced the ConversionException static factories with dedicated exception classes.
+     * The runtime conditional below can be inlined once DBAL 3 support is dropped.
+     * Excluded from coverage: only one branch can run for a given installed DBAL major.
+     *
+     * @codeCoverageIgnore
+     * @param string[] $possibleTypes
+     */
+    private function createInvalidTypeException(
+        mixed $value,
+        array $possibleTypes,
+        ?\Throwable $previous = null
+    ): ConversionException {
+        if (class_exists(InvalidType::class)) {
+            return InvalidType::new($value, self::TYPE, $possibleTypes, $previous);
+        }
+
+        return ConversionException::conversionFailedInvalidType($value, self::TYPE, $possibleTypes, $previous);
     }
 }

--- a/tests/Doctrine/DBAL/Types/PercentTypeTest.php
+++ b/tests/Doctrine/DBAL/Types/PercentTypeTest.php
@@ -9,16 +9,14 @@ use AssoConnect\PHPPercentBundle\Doctrine\DBAL\Types\PercentType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\Type;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class PercentTypeTest extends TestCase
 {
-    /**
-     * @var AbstractPlatform|MockObject
-     */
-    protected $platform;
+    protected AbstractPlatform&Stub $platform;
 
     /**
      * @var Type
@@ -30,15 +28,14 @@ class PercentTypeTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->platform = $this->getMockForAbstractClass(AbstractPlatform::class);
+        $this->platform = self::createStub(AbstractPlatform::class);
         $this->type = new PercentType();
     }
 
     /**
      * @param mixed $value
-     *
-     * @dataProvider invalidPHPValuesProvider
      */
+    #[DataProvider('invalidPHPValuesProvider')]
     public function testInvalidTypeConversionToDatabaseValue($value): void
     {
         $this->expectException(ConversionException::class);


### PR DESCRIPTION
- doctrine/dbal constraint: ^2.10|^3.0 -> ^3.6|^4.0 (CI lowest/highest covers both majors)
- PercentType: ConversionException static factories are DBAL 3 only; use Types\Exception\InvalidType when available (DBAL 4)
- Tests: getMockForAbstractClass() (removed in PHPUnit 12+) -> createStub, @dataProvider annotations -> attributes